### PR TITLE
Feature: Talisman level property

### DIFF
--- a/spyro2.pal.json
+++ b/spyro2.pal.json
@@ -48,6 +48,11 @@
                 "en-gb": "Glimmer",
                 "fr": "Lueur"
             },
+            "talisman": {
+                "name": {
+                    "en-gb": "Magic Pick"
+                }
+            },
             "homeworld": "/levels/0",
             "npcs": [
                 {

--- a/spyro2.schema.json
+++ b/spyro2.schema.json
@@ -148,6 +148,7 @@
                 "name": {
                     "$ref": "#/definitions/LocalisedText"
                 },
+                "talisman": { "$ref": "#/definitions/Talisman" },
                 "npcs": {
                     "type": "array",
                     "items": {
@@ -161,6 +162,14 @@
                     }
                 }
             }
+        },
+        "Talisman": {
+            "type": "object",
+            "description": "A level-specific reward for reaching the end of a level. This is not guaranteed on every level.",
+            "properties": {
+                "name": { "$ref": "#/definitions/LocalisedText" }
+            },
+            "required": ["name"]
         },
         "Portal": {
             "allOf": [


### PR DESCRIPTION
This pull request closes #7 by adding in a new optional property to levels: `talisman`. This has a `name` property but no other information.