### PR TITLE
Feature: Orbs level property

### DIFF
--- a/spyro2.pal.json
+++ b/spyro2.pal.json
@@ -16,6 +16,28 @@
             "name": {
                 "en-gb": "Summer Forest"
             },
+            "orbs": [
+                {
+                    "name": {
+                        "en-gb": "Hunter's challenge"
+                    }
+                },
+                {
+                    "name": {
+                        "en-gb": "On a secret ledge"
+                    }
+                },
+                {
+                    "name": {
+                        "en-gb": "Atop a ladder"
+                    }
+                },
+                {
+                    "name": {
+                        "en-gb": "Behind the door"
+                    }
+                }
+            ],
             "portals": [
                 {
                     "destination": "/levels/1",
@@ -53,6 +75,23 @@
                     "en-gb": "Magic Pick"
                 }
             },
+            "orbs": [
+                {
+                    "name": {
+                        "en-gb": "Lizard hunt"
+                    }
+                },
+                {
+                    "name": {
+                        "en-gb": "Gem Lamp Flight outdoors"
+                    }
+                },
+                {
+                    "name": {
+                        "en-gb": "Gem Lamp Flight in cave"
+                    }
+                }
+            ],
             "homeworld": "/levels/0",
             "npcs": [
                 {
@@ -123,6 +162,13 @@
             "name": {
                 "en-gb": "Ocean Speedway"
             },
+            "orbs": [
+                {
+                    "name": {
+                        "en-gb": "Follow Hunter"
+                    }
+                }
+            ],
             "homeworld": "/levels/0",
             "targets": [
                 {

--- a/spyro2.pal.json
+++ b/spyro2.pal.json
@@ -25,7 +25,8 @@
                 {
                     "name": {
                         "en-gb": "On a secret ledge"
-                    }
+                    },
+                    "location": "Starting from the wooded garden with a river running in the centre, follow the river until you reach a pool. Follow a hole in the bottom of that pool until you reach a room with large steps. Jump up the ledges and you will find the orb on a ledge overlooking the entrance to Colossus."
                 },
                 {
                     "name": {

--- a/spyro2.schema.json
+++ b/spyro2.schema.json
@@ -182,7 +182,8 @@
                     "type": "object",
                     "description": "A reward for completing a challenge. Levels can have multiple orbs and they can sometimes be the prerequisite for entering other levels.",
                     "properties": {
-                        "name": { "$ref": "#/definitions/LocalisedText" }
+                        "name": { "$ref": "#/definitions/LocalisedText" },
+                        "location": { "$ref": "#/definitions/Location" }
                     },
                     "required": ["name"]
                 }

--- a/spyro2.schema.json
+++ b/spyro2.schema.json
@@ -149,6 +149,10 @@
                     "$ref": "#/definitions/LocalisedText"
                 },
                 "talisman": { "$ref": "#/definitions/Talisman" },
+                "orbs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/Orb" }
+                },
                 "npcs": {
                     "type": "array",
                     "items": {
@@ -170,6 +174,20 @@
                 "name": { "$ref": "#/definitions/LocalisedText" }
             },
             "required": ["name"]
+        },
+        "Orb": {
+            "allOf": [
+                { "$ref": "#/definitions/HasPrerequisites" },
+                {
+                    "type": "object",
+                    "description": "A reward for completing a challenge. Levels can have multiple orbs and they can sometimes be the prerequisite for entering other levels.",
+                    "properties": {
+                        "name": { "$ref": "#/definitions/LocalisedText" }
+                    },
+                    "required": ["name"]
+                }
+        
+            ]
         },
         "Portal": {
             "allOf": [


### PR DESCRIPTION
This pull request closes #6 by adding the property `"orbs"` to levels. This is a list of orbs in the guidebook for that level whose order matches the guidebook and serves as an identifier for the orb.

A location is also specified to help identify the orb if its name is not clear enough. Although this is currently not required, it may become so as this database matures.