### PR TITLE
Bugfix: Portal's "location" type is incorrect

### DIFF
--- a/spyro2.schema.json
+++ b/spyro2.schema.json
@@ -198,7 +198,7 @@
                     "description": "An in-level object that allows for a transition into another level.",
                     "properties": {
                         "destination": { "$ref": "#/definitions/Reference" },
-                        "location": { "$ref": "#/definitions/DescriptiveText" }
+                        "location": { "$ref": "#/definitions/Location" }
                     },
                     "required": ["destination"]
                 }


### PR DESCRIPTION
This pull request changes the type for Portal's "location" property from "DescriptiveText" to "Location". Although these are equivalent, the latter is preferred in the case of locations requiring more information in the future.