### PR TITLE
Bugfix: Angular app could not find dependencies

### DIFF
--- a/.github/workflows/appbuilder.yaml
+++ b/.github/workflows/appbuilder.yaml
@@ -39,7 +39,10 @@ jobs:
         run: npm install
       
       - name: Build
-        run: npm run build --prod
+        run: npm run build --prod --base-href "https://$OWNER.github.io/$REPO_NAME/dist/app"
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: spyro2-database
 
       # - name: Test
       #   run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadless

--- a/app/src/app/level/level.component.html
+++ b/app/src/app/level/level.component.html
@@ -2,4 +2,4 @@
 <h2 *ngIf="level.name">
     <app-localised-text [localText]="level.name"></app-localised-text>
 </h2>
-<p>level works!!</p>
+<p>level works!</p>


### PR DESCRIPTION
This pull request fixes a bug for the deployed Angular application where it couldn't find dependencies such as `polyfill.js` or `main.js` when accessed via GitHub Pages.

This was due to the root relative location not being specified in the build process. This has been specified to be the equivalent of `https://tomchapple.github.io/spyro2-database/dist/app/` so it can find the dependencies as required.