### PR TITLE
Bugfix: Build flags not applied during GitHub Action

### DIFF
--- a/.github/workflows/appbuilder.yaml
+++ b/.github/workflows/appbuilder.yaml
@@ -39,7 +39,7 @@ jobs:
         run: npm install
       
       - name: Build
-        run: npm run build --prod --base-href "https://$OWNER.github.io/$REPO_NAME/dist/app"
+        run: npm run build -- --prod --base-href "https://$OWNER.github.io/$REPO_NAME/dist/app/"
         env:
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: spyro2-database

--- a/app/src/app/level/level.component.html
+++ b/app/src/app/level/level.component.html
@@ -2,4 +2,4 @@
 <h2 *ngIf="level.name">
     <app-localised-text [localText]="level.name"></app-localised-text>
 </h2>
-<p>level works!</p>
+<p>level works!!</p>


### PR DESCRIPTION
This pull request fixes a failure during the GitHub Action where it cannot find the app to build. This was due to the `--` not being provided in `npm run`.

Not only has this been added, but a slight misconfiguration has also been corrected for the `--base-href` URL.