### PR TITLE
Feature: Source data from GitHub static file

### DIFF
--- a/app/src/app/app.component.html
+++ b/app/src/app/app.component.html
@@ -1,4 +1,4 @@
 <h1>Spyro 2 Database</h1>
 
-<app-level [level]="level" *ngFor="let level of levels">
+<app-level [level]="level" *ngFor="let level of levels$ | async">
 </app-level>

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Spyro2Service } from './spyro2.service'
 import { Level } from './level'
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -13,7 +14,7 @@ export class AppComponent {
 
   title = 'app';
 
-  get levels(): Iterable<Level> {
-    return this.service.levels;
+  get levels$(): Observable<Iterable<Level>> {
+    return this.service.levels$;
   }
 }

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -17,7 +18,8 @@ import { LocalisedTextComponent } from './localised-text/localised-text.componen
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    HttpClientModule
   ],
   providers: [
     {provide: Spyro2Service, useClass: StaticFileSpyro2Service }

--- a/app/src/app/level/level.component.ts
+++ b/app/src/app/level/level.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { EMPTY, Observable } from 'rxjs';
 import { Level } from '../level';
-import { PreferencesService } from '../preferences.service';
 
 @Component({
   selector: 'app-level',
@@ -9,9 +9,9 @@ import { PreferencesService } from '../preferences.service';
 })
 export class LevelComponent implements OnInit {
 
-  constructor(private preferences: PreferencesService) {}
+  constructor() {}
 
-  @Input() level: Level = {name(string) { return ''; }}
+  @Input() level: Level = { name(locale) { return EMPTY } };
 
   ngOnInit(): void {
   }

--- a/app/src/app/localised-text.ts
+++ b/app/src/app/localised-text.ts
@@ -1,3 +1,6 @@
+import { Observable } from 'rxjs';
+import { Locale } from './locale';
+
 export interface LocalisedText {
     /**
      * Retrieves a value based on a specified locale.
@@ -14,5 +17,5 @@ export interface LocalisedText {
      *
      * @param locale The locale as an IETF language tag
      */
-    (locale: string): string;
+    (locale: Locale): Observable<string>;
 }

--- a/app/src/app/localised-text/localised-text.component.html
+++ b/app/src/app/localised-text/localised-text.component.html
@@ -1,1 +1,1 @@
-<span>{{preferredText}}</span>
+<span>{{preferredText$ | async}}</span>

--- a/app/src/app/localised-text/localised-text.component.ts
+++ b/app/src/app/localised-text/localised-text.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { Observable, EMPTY } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 import { LocalisedText } from '../localised-text';
 import { PreferencesService } from '../preferences.service';
 
@@ -9,15 +11,20 @@ import { PreferencesService } from '../preferences.service';
 })
 export class LocalisedTextComponent implements OnInit {
 
-  @Input('localText') localisedText: LocalisedText = (locale) => "";
+  @Input('localText') localisedText: LocalisedText = (locale) => EMPTY;
 
-  get preferredText(): String {
-    return this.localisedText(this.preferences.preferredLocale?.id ?? "");
+  _preferredText$: Observable<string> = EMPTY;
+
+  get preferredText$(): Observable<string> {
+    return this._preferredText$;
   }
 
   constructor(private preferences: PreferencesService) { }
 
   ngOnInit(): void {
+    this._preferredText$ = this.preferences.preferredLocale$.pipe(
+      mergeMap((locale) => this.localisedText(locale))
+    )
   }
 
 }

--- a/app/src/app/preferences.service.ts
+++ b/app/src/app/preferences.service.ts
@@ -1,24 +1,24 @@
 import { Injectable, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Locale } from './locale';
 import { Spyro2Service } from './spyro2.service';
 
 @Injectable({
   providedIn: 'root'
 })
-export class PreferencesService implements OnInit {
+export class PreferencesService {
 
-  constructor(private service: Spyro2Service) {  }
-
-  get locales(): Set<Locale> {
-    return this.service.locales;
+  constructor(private service: Spyro2Service) {
+    this.preferredLocale$ = this.locales$.pipe(
+      map(locales => locales.values().next().value)
+    );
   }
 
-  preferredLocale?: Locale;
-
-  ngOnInit() {
-    if (!this.preferredLocale) {
-      this.preferredLocale = this.locales.values().next().value;
-    }
+  get locales$(): Observable<Set<Locale>> {
+    return this.service.locales$;
   }
+
+  preferredLocale$: Observable<Locale>;
 }
 

--- a/app/src/app/spyro2.service.ts
+++ b/app/src/app/spyro2.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
 import { Level } from "./level";
 import { Locale } from "./locale";
 
 @Injectable()
 export abstract class Spyro2Service {
 
-    readonly abstract levels: Iterable<Level>;
+    readonly abstract levels$: Observable<Iterable<Level>>;
 
-    readonly abstract locales: Set<Locale>;
+    readonly abstract locales$: Observable<Set<Locale>>;
 }

--- a/app/src/app/static-file-spyro2.service.ts
+++ b/app/src/app/static-file-spyro2.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Level } from "./level";
 import { Locale } from "./locale";
 import { Spyro2Service } from './spyro2.service';
@@ -15,54 +16,10 @@ export class StaticFileSpyro2Service extends Spyro2Service {
   _levels$: Observable<Iterable<Level>>;
   _locales$: Observable<Set<Locale>>;
 
-  constructor() {
+  constructor(private http: HttpClient) {
     super();
 
-    this.database$ = from([{
-      locales: [
-        {
-          id: 'en-gb',
-          name: 'English'
-        }
-      ],
-      levels: [
-        {
-          name: {
-            'en-gb': 'Summer Forest'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Glimmer'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Idol Spring'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Colossus'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Hurricos'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Sunny Beach'
-          }
-        },
-        {
-          name: {
-            'en-gb': 'Aquaria Towers'
-          }
-        }
-      ]
-    }])
+    this.database$ = this.http.get('https://raw.githubusercontent.com/TomChapple/spyro2-database/main/spyro2.pal.json');
 
     this._levels$ = this.database$.pipe(
       map(db => db.levels.map(jsonToLevel))

--- a/app/src/app/static-file-spyro2.service.ts
+++ b/app/src/app/static-file-spyro2.service.ts
@@ -2,17 +2,92 @@ import { Injectable } from '@angular/core';
 import { Level } from "./level";
 import { Locale } from "./locale";
 import { Spyro2Service } from './spyro2.service';
+import { Observable, from, EMPTY } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { LocalisedText } from './localised-text';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StaticFileSpyro2Service extends Spyro2Service {
 
-  get levels(): Level[] {
-    return [{name(string) { return "Summer Forest"; }}];
+  database$: Observable<any>;
+  _levels$: Observable<Iterable<Level>>;
+  _locales$: Observable<Set<Locale>>;
+
+  constructor() {
+    super();
+
+    this.database$ = from([{
+      locales: [
+        {
+          id: 'en-gb',
+          name: 'English'
+        }
+      ],
+      levels: [
+        {
+          name: {
+            'en-gb': 'Summer Forest'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Glimmer'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Idol Spring'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Colossus'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Hurricos'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Sunny Beach'
+          }
+        },
+        {
+          name: {
+            'en-gb': 'Aquaria Towers'
+          }
+        }
+      ]
+    }])
+
+    this._levels$ = this.database$.pipe(
+      map(db => db.levels.map(jsonToLevel))
+    );
+    this._locales$ = this.database$.pipe(
+      map(db => db.locales),
+      map(locales => new Set(locales))
+    );
+  }
+
+  get levels$(): Observable<Iterable<Level>> {
+    return this._levels$;
   };
 
-  get locales(): Set<Locale> {
-    return new Set([{id: 'en-gb', name: 'English'}]);
+  get locales$(): Observable<Set<Locale>> {
+    return this._locales$;
   }
+}
+
+function jsonToLevel(obj: any): Level {
+  return {
+    name: obj.name ? jsonToLocalisedText(obj.name) : undefined
+  }
+}
+
+function jsonToLocalisedText(obj: any): LocalisedText {
+  return (locale) => obj[locale.id] ? from([obj[locale.id]]) : EMPTY;
 }


### PR DESCRIPTION
This pull request replaces the stub implementations for retrieving levels and locales with an HTTP query to the raw GitHub file where the database is stored on the "main" branch. This allows for the application to be up to date with any updates to the file as they happen instead of rebuilding the web app altogether.

To this end, the implementation now uses Observables in most places as this data is not immediate and is prone to change. This is especially resilient to future changes such as live updates as then the `database$` can stay open instead of closing once the HTTP request is complete.

The implementation of pulling the interface implementations from the database is a little messy and hopefully can be further iterated on later.